### PR TITLE
Geojson API endpoint for hazard exposure per administrative area

### DIFF
--- a/apps/administrative/api/serializers.py
+++ b/apps/administrative/api/serializers.py
@@ -21,6 +21,7 @@ __all__ = [
     "AreaMobileCoverageCSVSerializer",
     "AreaInternetSpeedSerializer",
     "AreaInternetSpeedCSVSerializer",
+    "AreaHazardExposureSerializer",
     "RelatedAreaSerializer",
 ]
 
@@ -393,3 +394,30 @@ class AreaInternetSpeedCSVSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = fields
+
+
+class BaseAreaHazardExpsoureSerializer(serializers.ModelSerializer):
+
+    population_exposed = serializers.IntegerField(read_only=True)
+    population_exposed_ev = serializers.IntegerField(read_only=True)
+    urbanization_degree_codes = serializers.ListField(child=serializers.SlugField(), read_only=True)
+
+
+class AreaHazardExposureSerializer(BaseAreaHazardExpsoureSerializer, BaseGeoFeatureModelSerializer):
+    """GeoJSON serializer for hazard exposure statistics in administrative areas."""
+
+    class Meta:
+        model = Area
+        id_field = "uuid"
+        geo_field = "geometry"
+        exclude = [
+            "id",
+            "depth",
+            "path",
+            "numchild",
+            "geom",
+            "population_male",
+            "population_female",
+            "created_at",
+            "updated_at",
+        ]

--- a/apps/administrative/api/urls.py
+++ b/apps/administrative/api/urls.py
@@ -13,3 +13,4 @@ router.register(
 
 router.register(r"areas-mobile-coverage", views.AreaMobileCoverageViewSet, basename="area-mobile-coverage")
 router.register(r"areas-internet-speed", views.AreaInternetSpeedViewSet, basename="area-internet-speed")
+router.register(r"areas-hazards-exposure", views.AreaHazardExposureViewSet, basename="area-hazards-exposure")

--- a/apps/administrative/api/views/__init__.py
+++ b/apps/administrative/api/views/__init__.py
@@ -1,3 +1,4 @@
 from .base import *  # noqa
 from .education import *  # noqa
-from .infrastructure import *  # noqa
+from .hazards import *  # noqa
+from .infrastructure import *  # noqa\

--- a/apps/administrative/api/views/hazards.py
+++ b/apps/administrative/api/views/hazards.py
@@ -1,0 +1,43 @@
+from django.conf import settings
+from django.contrib.postgres.aggregates import ArrayAgg
+from django.db.models import Q, Sum
+from django.utils.translation import gettext_lazy as _
+
+from drf_spectacular.utils import extend_schema, extend_schema_view
+
+from ...models import Area
+from ..serializers import AreaHazardExposureSerializer
+from .base import AreaViewSet
+
+__all__ = ["AreaHazardExposureViewSet"]
+
+
+@extend_schema_view(
+    list=extend_schema(
+        summary=_("Administrative Areas Hazard Exposure"),
+        description=_("Retrieve a list of administrative areas with hazard exposure statistics."),
+    ),
+    retrieve=extend_schema(
+        summary=_("Administrative Area Hazard Exposure"),
+        description=_("Retrieve details of an administrative area with hazard exposure statistics."),
+    ),
+)
+class AreaHazardExposureViewSet(AreaViewSet):
+    """Hazard Exposure summary for Administrative Areas API endpoint."""
+
+    serializer_class = AreaHazardExposureSerializer
+    ordering_fields = ["name", "created_at", "updated_at"]
+
+    def get_queryset(self):
+
+        qs = Area.objects.annotate(
+            population_exposed=Sum("hazards_exposure_coverage__exposure__population_exposed"),
+            population_exposed_ev=Sum("hazards_exposure_coverage__exposure__population_exposed_ev"),
+            urbanization_degree_codes=ArrayAgg(
+                "hazards_exposure_coverage__exposure__urbanization_degree__code",
+                distinct=True,
+                filter=~Q(hazards_exposure_coverage__exposure__urbanization_degree__code=None),
+            ),
+        )
+
+        return qs


### PR DESCRIPTION
Implements a new API endpoint for fetching hazard exposure per administrative area.
Added new serializers to viewset that aggregates population exposure and urbanization degree codes.

Endpoint 

`GET /api/administrative/area-hazards-exposure`

Example response

```json
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "id": "id-of-the-area",
      "geometry": {
        "type": "Polygon",
        "coordinates": [ ... ]
      },
  "properties": {
          "population_exposed": 232400,
          "population_exposed_ev": 600000,
          "urbanization_degree_codes": [
            "dense-urban-cluster",
            "low-density-rural",
            "rural-cluster",
          ],
          "area": 14860.818,
          "extras": {
          }
        }
    }
   ]
}
```