### PR TITLE
Support for CSV endpoint for hazards exposure per administrative area

### DIFF
--- a/apps/administrative/api/serializers.py
+++ b/apps/administrative/api/serializers.py
@@ -22,6 +22,7 @@ __all__ = [
     "AreaInternetSpeedSerializer",
     "AreaInternetSpeedCSVSerializer",
     "AreaHazardExposureSerializer",
+    "AreaHazardExpsoureCSVSerializer",
     "RelatedAreaSerializer",
 ]
 
@@ -421,3 +422,24 @@ class AreaHazardExposureSerializer(BaseAreaHazardExpsoureSerializer, BaseGeoFeat
             "created_at",
             "updated_at",
         ]
+
+class AreaHazardExpsoureCSVSerializer(BaseAreaHazardExpsoureSerializer):
+    """Serializer for administrative areas hazard exposure CSV export."""
+
+    class Meta:
+        model = Area
+        fields = [
+            "uuid",
+            "type_code",
+            "country",
+            "name",
+            "code",
+            "description",
+            "population_exposed",
+            "population_exposed_ev",
+            "urbanization_degree_codes",
+            "created_at",
+            "updated_at",
+        ]
+        read_only_fields = fields
+

--- a/apps/administrative/api/serializers.py
+++ b/apps/administrative/api/serializers.py
@@ -21,6 +21,7 @@ __all__ = [
     "AreaMobileCoverageCSVSerializer",
     "AreaInternetSpeedSerializer",
     "AreaInternetSpeedCSVSerializer",
+    "AreaHazardExposureSerializer",
     "RelatedAreaSerializer",
 ]
 
@@ -393,3 +394,30 @@ class AreaInternetSpeedCSVSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = fields
+
+
+class BaseAreaHazardExpsoureSerializer(serializers.ModelSerializer):
+
+    population_exposed = serializers.IntegerField(read_only=True)
+    population_exposed_ev = serializers.IntegerField(read_only=True)
+    urbanization_degree_codes = serializers.ListField(child=serializers.SlugField(), read_only=True)
+
+
+class AreaHazardExposureSerializer(BaseAreaHazardExpsoureSerializer, BaseGeoFeatureModelSerializer):
+    """GeoJSON serializer for hazard exposure statistics in administrative areas."""
+
+    class Meta:
+        model = Area
+        id_field = "uuid"
+        geo_field = "geometry"
+        exclude = [
+            "id",
+            "depth",
+            "path",
+            "numchild",
+            "geom",
+            "population_male",
+            "population_female",
+            "created_at",
+            "updated_at",
+        ]

--- a/apps/administrative/api/urls.py
+++ b/apps/administrative/api/urls.py
@@ -13,3 +13,4 @@ router.register(
 
 router.register(r"areas-mobile-coverage", views.AreaMobileCoverageViewSet, basename="area-mobile-coverage")
 router.register(r"areas-internet-speed", views.AreaInternetSpeedViewSet, basename="area-internet-speed")
+router.register(r"areas-hazards-exposure", views.AreaHazardExposureViewSet, basename="area-hazards-exposure")

--- a/apps/administrative/api/views/__init__.py
+++ b/apps/administrative/api/views/__init__.py
@@ -1,3 +1,4 @@
 from .base import *  # noqa
 from .education import *  # noqa
-from .infrastructure import *  # noqa
+from .hazards import *  # noqa
+from .infrastructure import *  # noqa\

--- a/apps/administrative/api/views/hazards.py
+++ b/apps/administrative/api/views/hazards.py
@@ -1,0 +1,43 @@
+from django.conf import settings
+from django.contrib.postgres.aggregates import ArrayAgg
+from django.db.models import Q, Sum
+from django.utils.translation import gettext_lazy as _
+
+from drf_spectacular.utils import extend_schema, extend_schema_view
+
+from ...models import Area
+from ..serializers import AreaHazardExposureSerializer
+from .base import AreaViewSet
+
+__all__ = ["AreaHazardExposureViewSet"]
+
+
+@extend_schema_view(
+    list=extend_schema(
+        summary=_("Administrative Areas Hazard Exposure"),
+        description=_("Retrieve a list of administrative areas with hazard exposure statistics."),
+    ),
+    retrieve=extend_schema(
+        summary=_("Administrative Area Hazard Exposure"),
+        description=_("Retrieve details of an administrative area with hazard exposure statistics."),
+    ),
+)
+class AreaHazardExposureViewSet(AreaViewSet):
+    """Hazard Exposure summary for Administrative Areas API endpoint."""
+
+    serializer_class = AreaHazardExposureSerializer
+    ordering_fields = ["name", "created_at", "updated_at"]
+
+    def get_queryset(self):
+
+        qs = Area.objects.annotate(
+            population_exposed=Sum("hazards_exposure_coverage__exposure__population_exposed"),
+            population_exposed_ev=Sum("hazards_exposure_coverage__exposure__population_exposed_ev"),
+            urbanization_degree_codes=ArrayAgg(
+                "hazards_exposure_coverage__exposure__urbanization_degree__code",
+                distinct=True,
+                filter=~Q(hazards_exposure_coverage__exposure__urbanization_degree__code=None),
+            ),
+        )
+
+        return qs

--- a/apps/administrative/api/views/hazards.py
+++ b/apps/administrative/api/views/hazards.py
@@ -1,12 +1,15 @@
-from django.conf import settings
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Q, Sum
 from django.utils.translation import gettext_lazy as _
+from django.utils.timezone import now
+
 
 from drf_spectacular.utils import extend_schema, extend_schema_view
+from rest_framework.decorators import action
+
 
 from ...models import Area
-from ..serializers import AreaHazardExposureSerializer
+from ..serializers import AreaHazardExposureSerializer, AreaHazardExpsoureCSVSerializer
 from .base import AreaViewSet
 
 __all__ = ["AreaHazardExposureViewSet"]
@@ -26,6 +29,8 @@ class AreaHazardExposureViewSet(AreaViewSet):
     """Hazard Exposure summary for Administrative Areas API endpoint."""
 
     serializer_class = AreaHazardExposureSerializer
+    csv_serializer_class = AreaHazardExpsoureCSVSerializer
+
     ordering_fields = ["name", "created_at", "updated_at"]
 
     def get_queryset(self):
@@ -41,3 +46,19 @@ class AreaHazardExposureViewSet(AreaViewSet):
         )
 
         return qs
+
+    def get_csv_file_name(self):
+        """Return name of the CSV file produced."""
+        return f"areas-hazards-exposure-summary-{now().date()}.csv"
+
+    @action(
+        detail=False,
+        methods=["get"],
+        name="Download areas hazards exposure statistics CSV",
+        url_path="download",
+        url_name="list-download",
+    )
+    def download(self, request, *args, **kwargs):
+        """Download Areas Hazard Exposure Statistics as CSV."""
+
+        return self.export_csv(request, *args, **kwargs)


### PR DESCRIPTION
Adds endpoint that supports CSV download of the hazards exposure per administrative area.

Endpoint

`GET /api/administrative/areas-hazard-exposure/download`

Example CSV hazard exposure related fields

population_exposed | population_exposed_ev | urbanization_degree_codes
-- | -- | --
1000057 | 200000 | ['dense-urban-cluster', 'low-density-rural', 'rural-cluster'']
200000 | 700000 | ['dense-urban-cluster', 'low-density-rural', 'rural-cluster', 'water']
800000 | 500000| ['dense-urban-cluster', 'water']
