### PR TITLE
Add hazard exposure area endpoint filters

### DIFF
--- a/apps/administrative/api/filters.py
+++ b/apps/administrative/api/filters.py
@@ -2,7 +2,7 @@ from django_filters import rest_framework as filters
 
 from ..models import Area
 
-__all__ = ["AreaFilter"]
+__all__ = ["AreaFilter", "AreaHazardExposureFilter"]
 
 
 class AreaFilter(filters.FilterSet):
@@ -11,3 +11,22 @@ class AreaFilter(filters.FilterSet):
     class Meta:
         model = Area
         fields = ["uuid", "level", "country"]
+
+
+class CommaSeparatedCharFilter(filters.BaseCSVFilter, filters.CharFilter):
+    pass
+
+
+class AreaHazardExposureFilter(filters.FilterSet):
+
+    administrative_area_level = filters.NumberFilter(field_name="depth")
+    hazard_type = CommaSeparatedCharFilter(
+        field_name="hazards_exposure_coverage__exposure__hazards__code", lookup_expr="in"
+    )
+    urbanization_degree = CommaSeparatedCharFilter(
+        field_name="hazards_exposure_coverage__exposure__urbanization_degree__code", lookup_expr="in"
+    )
+
+    class Meta:
+        model = Area
+        fields = ["administrative_area_level", "hazard_type", "urbanization_degree"]

--- a/apps/administrative/api/serializers.py
+++ b/apps/administrative/api/serializers.py
@@ -401,6 +401,7 @@ class BaseAreaHazardExpsoureSerializer(serializers.ModelSerializer):
     population_exposed = serializers.IntegerField(read_only=True)
     population_exposed_ev = serializers.IntegerField(read_only=True)
     urbanization_degree_codes = serializers.ListField(child=serializers.SlugField(), read_only=True)
+    hazard_codes = serializers.ListField(child=serializers.SlugField(), read_only=True)
 
 
 class AreaHazardExposureSerializer(BaseAreaHazardExpsoureSerializer, BaseGeoFeatureModelSerializer):

--- a/apps/administrative/api/serializers.py
+++ b/apps/administrative/api/serializers.py
@@ -21,6 +21,7 @@ __all__ = [
     "AreaMobileCoverageCSVSerializer",
     "AreaInternetSpeedSerializer",
     "AreaInternetSpeedCSVSerializer",
+    "AreaHazardExposureSerializer",
     "RelatedAreaSerializer",
 ]
 
@@ -393,3 +394,30 @@ class AreaInternetSpeedCSVSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = fields
+
+
+class BaseAreaHazardExpsoureSerializer(serializers.ModelSerializer):
+
+    population_exposed = serializers.IntegerField(read_only=True)
+    population_exposed_ev = serializers.IntegerField(read_only=True)
+    urbanization_degree_codes = serializers.ListField(child=serializers.SlugField(), read_only=True)
+
+
+class AreaHazardExposureSerializer(BaseAreaHazardExpsoureSerializer, BaseGeoFeatureModelSerializer):
+    """GeoJSON serializer for hazard exposure statistics in administrative areas."""
+
+    class Meta:
+        model = Area
+        id_field = "uuid"
+        geo_field = "geometry"
+        exclude = [
+            "id",
+            "depth",
+            "path",
+            "numchild",
+            "geom",
+            "population_male",
+            "population_female",
+            "created_at",
+            "updated_at",
+        ]

--- a/apps/administrative/api/urls.py
+++ b/apps/administrative/api/urls.py
@@ -13,3 +13,4 @@ router.register(
 
 router.register(r"areas-mobile-coverage", views.AreaMobileCoverageViewSet, basename="area-mobile-coverage")
 router.register(r"areas-internet-speed", views.AreaInternetSpeedViewSet, basename="area-internet-speed")
+router.register(r"areas-hazards-exposure", views.AreaHazardExposureViewSet, basename="area-hazards-exposure")

--- a/apps/administrative/api/views/__init__.py
+++ b/apps/administrative/api/views/__init__.py
@@ -1,3 +1,4 @@
 from .base import *  # noqa
 from .education import *  # noqa
-from .infrastructure import *  # noqa
+from .hazards import *  # noqa
+from .infrastructure import *  # noqa\

--- a/apps/administrative/api/views/hazards.py
+++ b/apps/administrative/api/views/hazards.py
@@ -1,11 +1,12 @@
-from django.conf import settings
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Q, Sum
 from django.utils.translation import gettext_lazy as _
 
+from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
 
 from ...models import Area
+from ..filters import AreaHazardExposureFilter
 from ..serializers import AreaHazardExposureSerializer
 from .base import AreaViewSet
 
@@ -27,6 +28,8 @@ class AreaHazardExposureViewSet(AreaViewSet):
 
     serializer_class = AreaHazardExposureSerializer
     ordering_fields = ["name", "created_at", "updated_at"]
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = AreaHazardExposureFilter
 
     def get_queryset(self):
 
@@ -37,6 +40,11 @@ class AreaHazardExposureViewSet(AreaViewSet):
                 "hazards_exposure_coverage__exposure__urbanization_degree__code",
                 distinct=True,
                 filter=~Q(hazards_exposure_coverage__exposure__urbanization_degree__code=None),
+            ),
+            hazard_codes=ArrayAgg(
+                "hazards_exposure_coverage__exposure__hazards__code",
+                distinct=True,
+                filter=~Q(hazards_exposure_coverage__exposure__hazards__code=None),
             ),
         )
 

--- a/apps/administrative/api/views/hazards.py
+++ b/apps/administrative/api/views/hazards.py
@@ -1,0 +1,43 @@
+from django.conf import settings
+from django.contrib.postgres.aggregates import ArrayAgg
+from django.db.models import Q, Sum
+from django.utils.translation import gettext_lazy as _
+
+from drf_spectacular.utils import extend_schema, extend_schema_view
+
+from ...models import Area
+from ..serializers import AreaHazardExposureSerializer
+from .base import AreaViewSet
+
+__all__ = ["AreaHazardExposureViewSet"]
+
+
+@extend_schema_view(
+    list=extend_schema(
+        summary=_("Administrative Areas Hazard Exposure"),
+        description=_("Retrieve a list of administrative areas with hazard exposure statistics."),
+    ),
+    retrieve=extend_schema(
+        summary=_("Administrative Area Hazard Exposure"),
+        description=_("Retrieve details of an administrative area with hazard exposure statistics."),
+    ),
+)
+class AreaHazardExposureViewSet(AreaViewSet):
+    """Hazard Exposure summary for Administrative Areas API endpoint."""
+
+    serializer_class = AreaHazardExposureSerializer
+    ordering_fields = ["name", "created_at", "updated_at"]
+
+    def get_queryset(self):
+
+        qs = Area.objects.annotate(
+            population_exposed=Sum("hazards_exposure_coverage__exposure__population_exposed"),
+            population_exposed_ev=Sum("hazards_exposure_coverage__exposure__population_exposed_ev"),
+            urbanization_degree_codes=ArrayAgg(
+                "hazards_exposure_coverage__exposure__urbanization_degree__code",
+                distinct=True,
+                filter=~Q(hazards_exposure_coverage__exposure__urbanization_degree__code=None),
+            ),
+        )
+
+        return qs


### PR DESCRIPTION
Contain changes from https://github.com/tehamalab/iipdash/pull/161

Introduces updates to the `/api/administrative/areas-hazards-exposure` endpoint to include filters for the following fields `administrative level`, `hazard type` and `urbanization degree`.

The filter for `hazard type` and `urbanization degree` support multiple values filtering by allowing comma separated values, see below examples.

At the moment the filtering `hazard type` support the hazard code, for the `urbanization degree` field the urbanization degree code is used for the filter values.

**Filtering examples**

Get areas that have hazard type `drought`

`/api/administrative/areas-hazards-exposure/?hazard_type=drought`

Get areas that have hazard type `drought` and `flood`

`/api/administrative/areas-hazards-exposure/?hazard_type=drought,flood`


